### PR TITLE
fixed height bug to be fixed when user zooms in 

### DIFF
--- a/web/templates/password/new.html.eex
+++ b/web/templates/password/new.html.eex
@@ -1,10 +1,10 @@
 <div class="vh-100 w-100 mw7-ns center dt">
   <div class="dtc v-mid">
-    <div class="ba b--black-10 br4 pa4 bg-white h-75-ns h-100">
+    <div class="ba b--black-10 br4 pa4 bg-white h-auto-ns h-100">
       <div class="tc pt5">
         <img src="/images/logo-blue.png" class="k-w4-5"/>
       </div>
-      <div class="mt4">
+      <div class="mt4 mb6">
         <%= form_for @changeset, password_path(@conn, :create), fn f -> %>
           <%= if @changeset.action do %>
             <div class="alert alert-danger">


### PR DESCRIPTION
# ready for review

- set a fixed height to all login flow windows so that when the user zooms in content always stays contained

fixes #250