### PR TITLE
fix vehicle allowance per week bug

### DIFF
--- a/test/models/startpack_test.exs
+++ b/test/models/startpack_test.exs
@@ -288,7 +288,7 @@ defmodule Karma.StartpackTest do
 
   # vehicle allowance changeset tests (conditionally required fields depending on vehicle_allowance_per_week)
   test "validating startpack with no vehicle allowance returns without adding validations" do
-    offer = %{vehicle_allowance_per_week: "£ 0.00"}
+    offer = %{vehicle_allowance_per_week: 0}
     valid = %{ @valid_attrs | vehicle_make: "" }
     changeset = Startpack.vehicle_allowance_changeset(%Startpack{}, valid, offer)
     # changeset function will not touch the startpack struct as vehicle allowance is 0

--- a/web/models/startpack.ex
+++ b/web/models/startpack.ex
@@ -293,7 +293,7 @@ defmodule Karma.Startpack do
   end
 
   def vehicle_allowance_changeset(changeset, startpack, offer) do
-    case offer.vehicle_allowance_per_week != "£ 0.00" do
+    case offer.vehicle_allowance_per_week != 0 do
       true ->
         changeset
         |> cast(startpack, vehicle_allowance_keys())


### PR DESCRIPTION
# ready
In offer/startpack changeset, vehicle fields were always required even if there was no allowance

#524 - 